### PR TITLE
proof of concept - page scrolling added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4221,15 +4221,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "requires": {
-        "object-assign": "^4",
-        "vary": "^1"
-      }
-    },
     "cosmiconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@types/react-dom": "^17.0.0",
     "@types/react-redux": "^7.1.16",
     "axios": "^0.21.1",
-    "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,28 +1,16 @@
 import React from "react";
 import { SearchBar } from "./components/searchBar/SearchBar";
 import { RecipeList } from "./components/recipeList/RecipeList";
-import { useDispatch } from "react-redux";
-import { SHOW_NEXT_PAGE } from "./redux/actions";
+import { PageNavigation } from "./components/pageNavigation/PageNavigation";
 
 const App: React.FunctionComponent = () => {
 
-  const dispatch = useDispatch();
-
-
-  const nextPage = () => {
-    dispatch(SHOW_NEXT_PAGE());
-    window.scrollTo({
-      top: 0,
-      behavior: "smooth"
-    });
-
-  };
   return (
     <div className="App">
       <h1>Goustito</h1>
       <SearchBar />
       <RecipeList />
-      <button onClick={nextPage}>Next</button>
+      <PageNavigation />
     </div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,23 @@
 import React from "react";
 import { SearchBar } from "./components/searchBar/SearchBar";
 import { RecipeList } from "./components/recipeList/RecipeList";
+import { useDispatch } from "react-redux";
+import { SHOW_NEXT_PAGE } from "./redux/actions";
 
 const App: React.FunctionComponent = () => {
+
+  const dispatch = useDispatch();
+
+  const nextPage = () => {
+    dispatch(SHOW_NEXT_PAGE());
+
+  };
   return (
     <div className="App">
       <h1>Goustito</h1>
       <SearchBar />
       <RecipeList />
+      <button onClick={nextPage}>Next</button>
     </div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,13 @@ const App: React.FunctionComponent = () => {
 
   const dispatch = useDispatch();
 
+
   const nextPage = () => {
     dispatch(SHOW_NEXT_PAGE());
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth"
+    });
 
   };
   return (

--- a/src/components/pageNavigation/PageNavigation.tsx
+++ b/src/components/pageNavigation/PageNavigation.tsx
@@ -7,7 +7,9 @@ const PageNavigation: React.FunctionComponent = () => {
 
     const dispatch = useDispatch();
     const startOfList = useSelector<RecipeState, boolean>((state) => state.resultsShown.from === 0)
-
+    const endOfList = useSelector<RecipeState, boolean>((state) =>
+        (state.resultsShown.to % 100 === 99)
+    )
     const changePage = (direction: string): void => {
         if (direction === "next") {
             dispatch(SHOW_NEXT_PAGE());
@@ -22,11 +24,12 @@ const PageNavigation: React.FunctionComponent = () => {
     };
     //todo - move this logic to scss
     const showPrevious = { display: startOfList ? "none" : "" }
+    const showNext = { display: endOfList ? "none" : "" }
 
     return (
         <div className="page-navigation">
             <button style={showPrevious} onClick={() => changePage("previous")}>Previous</button>
-            <button onClick={() => changePage("next")}>Next</button>
+            <button style={showNext} onClick={() => changePage("next")}>Next</button>
         </div>
     )
 }

--- a/src/components/pageNavigation/PageNavigation.tsx
+++ b/src/components/pageNavigation/PageNavigation.tsx
@@ -1,0 +1,33 @@
+import { useDispatch, useSelector } from "react-redux";
+import { SHOW_NEXT_PAGE, SHOW_PREVIOUS_PAGE } from "../../redux/actions";
+import { RecipeState } from "../../redux/reducer";
+
+
+const PageNavigation: React.FunctionComponent = () => {
+
+    const dispatch = useDispatch();
+    const startOfList = useSelector<RecipeState, boolean>((state) => state.resultsShown.from === 0)
+
+    const changePage = (direction: string): void => {
+        if (direction === "next") {
+            dispatch(SHOW_NEXT_PAGE());
+        }
+        if (direction === "previous") {
+            dispatch(SHOW_PREVIOUS_PAGE())
+        }
+        window.scrollTo({
+            top: 0,
+            behavior: "smooth"
+        });
+    };
+    //todo - move this logic to scss
+    const showPrevious = { display: startOfList ? "none" : "" }
+
+    return (
+        <div className="page-navigation">
+            <button style={showPrevious} onClick={() => changePage("previous")}>Previous</button>
+            <button onClick={() => changePage("next")}>Next</button>
+        </div>
+    )
+}
+export { PageNavigation }

--- a/src/components/recipeList/RecipeList.tsx
+++ b/src/components/recipeList/RecipeList.tsx
@@ -1,11 +1,26 @@
 import { useSelector } from "react-redux";
 import { Recipe } from "./Recipe";
 import { RecipeState } from "../../redux/reducer";
+import { useEffect, useState } from "react";
+
+interface ResultsShown {
+    from: number,
+    to: number
+}
 
 const RecipeList: React.FunctionComponent = () => {
 
-    const currentRecipes: any = useSelector<RecipeState>((state) => state.recipes[0]);
+    const [currentRecipes, setCurrentRecipes] = useState([])
 
+    const allRecipes: any = useSelector<RecipeState>((state) => state.recipes[0]);
+    const resultsToShow = useSelector<RecipeState, ResultsShown>((state) => state.resultsShown)
+
+    useEffect(() => {
+        const recipesToShow = allRecipes?.slice(resultsToShow.from, resultsToShow.to)
+        setCurrentRecipes(recipesToShow)
+    },
+        [resultsToShow, allRecipes]
+    )
     return (
         <section className="recipe-list">
             <ul>

--- a/src/components/recipeList/RecipeList.tsx
+++ b/src/components/recipeList/RecipeList.tsx
@@ -40,7 +40,7 @@ const RecipeList: React.FunctionComponent = () => {
                             </li>
                         );
                     })
-                };
+                }
             </ul>
         </section>
     );

--- a/src/components/searchBar/SearchBar.tsx
+++ b/src/components/searchBar/SearchBar.tsx
@@ -13,6 +13,7 @@ const SearchBar: React.FunctionComponent = () => {
     const [searchTerms, setSearchTerms] = useState<string>("");
     const [checkedMealTypes, setCheckedMealTypes] = useState<Array<string>>([]);
 
+
     const handleSearch = async (event: React.FormEvent) => {
         event.preventDefault();
         const results = await recipeRequests.searchByName(searchTerms, checkedMealTypes);
@@ -55,7 +56,6 @@ const SearchBar: React.FunctionComponent = () => {
                     )
                 })
             }
-
             <input
                 type="submit"
             />

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -5,7 +5,7 @@ export type Recipe = {
 }
 
 
-const SET_RECIPES = (recipes: Recipe[]) => {
+export const SET_RECIPES = (recipes: Recipe[]) => {
     return {
         type: "SET_RECIPES",
         payload: {
@@ -13,7 +13,11 @@ const SET_RECIPES = (recipes: Recipe[]) => {
         }
     }
 }
+export const SHOW_NEXT_PAGE = () => {
+    return {
+        type: "SHOW_NEXT_PAGE"
+    }
+}
 
 export type Actions = ReturnType<typeof SET_RECIPES>
 
-export { SET_RECIPES }

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -18,6 +18,11 @@ export const SHOW_NEXT_PAGE = () => {
         type: "SHOW_NEXT_PAGE"
     }
 }
+export const SHOW_PREVIOUS_PAGE = () => {
+    return {
+        type: "SHOW_PREVIOUS_PAGE"
+    }
+}
 
 export type Actions = ReturnType<typeof SET_RECIPES>
 

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -36,7 +36,7 @@ const recipeReducer: any = (state: RecipeState = initialState, action: Actions) 
                     to: state.resultsShown.to + 10
                 }
             }
-        case "DECREASE_FROM_TO":
+        case "SHOW_PREVIOUS_PAGE":
             return {
                 ...state,
                 resultsShown: {

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -13,7 +13,7 @@ const initialState = {
     recipes: [],
     resultsShown: {
         from: 0,
-        to: 10
+        to: 9
     }
 };
 
@@ -25,9 +25,17 @@ const recipeReducer: any = (state: RecipeState = initialState, action: Actions) 
                 recipes: [action.payload.recipes],
                 resultsShown: {
                     from: 0,
-                    to: 10
+                    to: 9
                 }
             };
+        case "ADD_RECIPES":
+            return {
+                ...state,
+                recipes: [
+                    ...state.recipes,
+                    action.payload.recipes
+                ]
+            }
         case "SHOW_NEXT_PAGE":
             return {
                 ...state,

--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -3,20 +3,47 @@ import { Actions } from "./actions";
 
 export interface RecipeState {
     recipes: string[];
+    resultsShown: {
+        from: number,
+        to: number
+    }
 };
 
 const initialState = {
-    recipes: []
+    recipes: [],
+    resultsShown: {
+        from: 0,
+        to: 10
+    }
 };
-
 
 const recipeReducer: any = (state: RecipeState = initialState, action: Actions) => {
     switch (action.type) {
         case "SET_RECIPES":
             return {
                 ...state,
-                recipes: [action.payload.recipes]
+                recipes: [action.payload.recipes],
+                resultsShown: {
+                    from: 0,
+                    to: 10
+                }
             };
+        case "SHOW_NEXT_PAGE":
+            return {
+                ...state,
+                resultsShown: {
+                    from: state.resultsShown.from + 10,
+                    to: state.resultsShown.to + 10
+                }
+            }
+        case "DECREASE_FROM_TO":
+            return {
+                ...state,
+                resultsShown: {
+                    from: state.resultsShown.from - 10,
+                    to: state.resultsShown.to - 10
+                }
+            }
         default:
             return state;
     };


### PR DESCRIPTION
closes #9 

As per issue ticket, I decided to go for the option of getting multiple pages of recipes per request (100 is the max in the free API), saving them to the redux store (eventually should look into caching properly), and rendering 10 results per page

Need to find way of scrolling back to top of page on clicking through to next set of 10 results.

Need to implement logic to make new request when all 100 have been scrolled through.

