### PR TITLE
Linked signup form to backend

### DIFF
--- a/src/components/login/SignupForm.tsx
+++ b/src/components/login/SignupForm.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import { UserDetailsForm } from "./UserDetailsForm/UserDetailsForm";
 import { Notification, MessageType } from "../pageElements/notification/Notification";
 import { useNotification } from "../../hooks/useNotification";
+import { signUpService } from "../../services/signUp";
+import { Credentials } from "../../services/login";
 
 interface SignupFormProps {
 	hidden: boolean
@@ -12,10 +14,22 @@ const SignupForm: React.FunctionComponent<SignupFormProps> = ({ hidden }) => {
 
 	const [notification, setNotification] = useNotification();
 
-	const handleSignup = (event: React.FormEvent<HTMLFormElement>, username: string, password: string) => {
+	const handleSignup = async (
+		event: React.FormEvent<HTMLFormElement>,
+		username: string,
+		password: string
+	) => {
 		event.preventDefault();
-		setNotification({ type: MessageType.message, message: "test" });
-		return;
+		try {
+			const credentials: Credentials = {
+				username,
+				password
+			};
+			const response = await signUpService.createNewUser(credentials);
+			setNotification({ type: MessageType.message, message: `${response.data.username} signed up successfully!` });
+		} catch (e) {
+			setNotification({ type: MessageType.error, message: `${e.e.response.data.error}` });
+		}
 	};
 
 	return (

--- a/src/services/signUp.ts
+++ b/src/services/signUp.ts
@@ -1,0 +1,16 @@
+import axios, { AxiosResponse } from "axios";
+import { Credentials } from "./login";
+
+const baseUrl = "http://localhost:3001";
+
+export const signUpService = {
+	async createNewUser(credentials: Credentials): Promise<AxiosResponse> {
+		const request = `${baseUrl}/api/user/signup`;
+		try {
+			const response = await axios.post(request, credentials);
+			return response;
+		} catch (e) {
+			throw { e };
+		}
+	}
+};


### PR DESCRIPTION
closes #47 

Linked the signup form to the backend/database - user creation and login are now functional, although logging in is currently meaningless - next steps are creating space in the store for user details, and implementing JSON web tokens for session persistence/validation.