### PR TITLE
Save username to store on successful login

### DIFF
--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -4,8 +4,12 @@ import { UserDetailsForm } from "./UserDetailsForm/UserDetailsForm";
 import { Notification, MessageType } from "../pageElements/notification/Notification";
 import { useNotification } from "../../hooks/useNotification";
 import { loginService } from "../../services/login";
+import { useDispatch } from "react-redux";
+import { SET_USER_DETAILS } from "../../redux/actions";
 
 const LoginForm: React.FunctionComponent = () => {
+
+	const dispatch = useDispatch();
 
 	const [notification, setNotification] = useNotification();
 
@@ -17,6 +21,7 @@ const LoginForm: React.FunctionComponent = () => {
 				password
 			});
 			const user = response.data;
+			dispatch(SET_USER_DETAILS(user.username, null));
 			setNotification({ type: MessageType.error, message: `${user.username} logged in successfully` });
 			return;
 		} catch (e) {

--- a/src/components/pageElements/header/Navbar.tsx
+++ b/src/components/pageElements/header/Navbar.tsx
@@ -1,7 +1,12 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
+import { AppState } from "../../../redux/store";
 
 const Navbar: React.FunctionComponent = () => {
+
+	const currentUser = useSelector<AppState, string | null>(state => state.users.user.username);
+
 	return (
 		<nav>
 			<ul>
@@ -12,7 +17,12 @@ const Navbar: React.FunctionComponent = () => {
 					<Link to="/feed">FEED</Link>
 				</li>
 				<li>
-					<Link to="/login">LOGIN</Link>
+					{
+						currentUser ?
+							<Link to="/vault">{`${currentUser.toUpperCase()}'S VAULT`}</Link>
+							:
+							<Link to="/login">LOGIN</Link>
+					}
 				</li>
 			</ul>
 		</nav>

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -58,7 +58,7 @@ export const SHOW_PREVIOUS_PAGE = (): PlainAction => {
 	};
 };
 
-export const SET_USER_DETAILS = (username: string, token: string): ActionWithUserPayload => {
+export const SET_USER_DETAILS = (username: string, token: string | null): ActionWithUserPayload => {
 	return {
 		type: "SET_USER_DETAILS",
 		payload: {


### PR DESCRIPTION
This is the last commit to prepare the stage for introducing tokens.

Username is now dispatched to the store on a successful login, and the login Link in the navbar gets replaced by a link to "${username}'s vault".