### PR TITLE
Save recipes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11727,6 +11727,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
     },
+    "react-icons": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.2.0.tgz",
+      "integrity": "sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ=="
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^10.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-icons": "^4.2.0",
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import { Home } from "./components/home/Home";
 import { LoginPage } from "./components/login/LoginPage";
 import { Header } from "./components/pageElements/header/Header";
+import { UserVault } from "./components/vault/UserVault";
 
 import "./app.scss";
 
@@ -24,6 +25,9 @@ const App: React.FunctionComponent = () => {
 						</Route>
 						<Route path="/login">
 							<LoginPage />
+						</Route>
+						<Route path="/vault">
+							<UserVault />
 						</Route>
 					</Switch>
 

--- a/src/components/home/recipeList/RecipeList.tsx
+++ b/src/components/home/recipeList/RecipeList.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 
-import { RecipeState } from "../../../redux/recipeReducer";
 import { AppState } from "../../../redux/store";
 import { RecipeType } from "../../../services/recipes";
 import { InfoBar } from "./InfoBar";
-import { Recipe } from "./Recipe";
+import { Recipe } from "./recipe/Recipe";
 
 import "./recipeList.scss";
 

--- a/src/components/home/recipeList/recipe/Recipe.tsx
+++ b/src/components/home/recipeList/recipe/Recipe.tsx
@@ -1,25 +1,43 @@
 import React from "react";
 
-import { useTogglable } from "../../../hooks/useTogglable";
-import { IngredientList } from "./IngredientList";
-import { RecipeType } from "../../../services/recipes";
+import { useTogglable } from "../../../../hooks/useTogglable";
+import { IngredientList } from "../IngredientList";
+import { RecipeType } from "../../../../services/recipes";
+import { SaveButton } from "./SaveButton";
 
 import "./recipe.scss";
+import { useDispatch } from "react-redux";
+import { SAVE_USER_RECIPE } from "../../../../redux/actions";
 
 interface RecipeProps {
 	recipe: RecipeType
 }
 
 const Recipe: React.FunctionComponent<RecipeProps> = ({ recipe }) => {
+	const dispatch = useDispatch();
+
 	const [isHidden, setIsHidden] = useTogglable(true);
+	const [isSaved, setIsSaved] = useTogglable(false);
 	//todo -find a way to stop event bubbling when clicking on "a" tag - maybe switch to span?
-	const { label, url, img, calories, source, ingredients, servings } = recipe;
+	const { id, label, url, img, calories, source, ingredients, servings } = recipe;
+
+	const saveRecipe = (event: React.MouseEvent) => {
+		event.stopPropagation();
+		setIsSaved();
+		dispatch(SAVE_USER_RECIPE(id));
+
+	};
 	return (
 		<section
 			className="recipe"
 			onClick={setIsHidden}
 		>
 			<h1>{label}</h1>
+			<SaveButton
+				onClick={saveRecipe}
+				isSaved={isSaved}
+			/>
+
 			<div className={`${isHidden && "hide"}`}>
 				<IngredientList ingredients={ingredients} />
 				<p>Calories: {Math.floor(calories)}</p>

--- a/src/components/home/recipeList/recipe/Recipe.tsx
+++ b/src/components/home/recipeList/recipe/Recipe.tsx
@@ -21,6 +21,7 @@ const Recipe: React.FunctionComponent<RecipeProps> = ({ recipe }) => {
 	const dispatch = useDispatch();
 	//todo - move this up to RecipeList component
 	const savedRecipes = useSelector<AppState, string[]>(state => state.users.recipes);
+	const currentUser = useSelector<AppState, string | null>(state => state.users.user.username);
 
 	const [isHidden, setIsHidden] = useTogglable(true);
 	const [isSaved, setIsSaved] = useTogglable(false);
@@ -35,7 +36,9 @@ const Recipe: React.FunctionComponent<RecipeProps> = ({ recipe }) => {
 		event.stopPropagation();
 		if (!isSaved) {
 			setIsSaved();
-			dispatch(SAVE_USER_RECIPE(id));
+			if (currentUser) {
+				dispatch(SAVE_USER_RECIPE(id, currentUser));
+			}
 			return;
 		}
 		setIsSaved();

--- a/src/components/home/recipeList/recipe/Recipe.tsx
+++ b/src/components/home/recipeList/recipe/Recipe.tsx
@@ -6,27 +6,44 @@ import { RecipeType } from "../../../../services/recipes";
 import { SaveButton } from "./SaveButton";
 
 import "./recipe.scss";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { SAVE_USER_RECIPE } from "../../../../redux/actions";
+import { AppState } from "../../../../redux/store";
+import { useEffect } from "react";
 
 interface RecipeProps {
 	recipe: RecipeType
 }
 
 const Recipe: React.FunctionComponent<RecipeProps> = ({ recipe }) => {
+
+	const { id, label, url, img, calories, source, ingredients, servings } = recipe;
 	const dispatch = useDispatch();
+	//todo - move this up to RecipeList component
+	const savedRecipes = useSelector<AppState, string[]>(state => state.users.recipes);
 
 	const [isHidden, setIsHidden] = useTogglable(true);
 	const [isSaved, setIsSaved] = useTogglable(false);
-	//todo -find a way to stop event bubbling when clicking on "a" tag - maybe switch to span?
-	const { id, label, url, img, calories, source, ingredients, servings } = recipe;
+
+	useEffect(() => {
+		if (savedRecipes.includes(id)) {
+			setIsSaved(true);
+		}
+	}, []);
 
 	const saveRecipe = (event: React.MouseEvent) => {
 		event.stopPropagation();
+		if (!isSaved) {
+			setIsSaved();
+			dispatch(SAVE_USER_RECIPE(id));
+			return;
+		}
 		setIsSaved();
-		dispatch(SAVE_USER_RECIPE(id));
+		//dispatch(DELETE_USER_RECIPE(id));
+		return;
 
 	};
+	//todo -find a way to stop event bubbling when clicking on "a" tag - maybe switch to span?
 	return (
 		<section
 			className="recipe"

--- a/src/components/home/recipeList/recipe/SaveButton.tsx
+++ b/src/components/home/recipeList/recipe/SaveButton.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { AiFillStar, AiOutlineStar } from "react-icons/ai";
+
+export type SaveButtonProps = {
+	onClick: (event: React.MouseEvent) => void,
+	isSaved: boolean
+}
+
+const SaveButton: React.FunctionComponent<SaveButtonProps> = ({ onClick, isSaved }) => {
+	return (
+		<div onClick={onClick}>
+			{
+				isSaved ?
+					<AiFillStar />
+					:
+					<AiOutlineStar />
+			}
+		</div>
+	);
+};
+
+
+export { SaveButton };

--- a/src/components/home/recipeList/recipe/recipe.scss
+++ b/src/components/home/recipeList/recipe/recipe.scss
@@ -8,7 +8,7 @@
     box-sizing: border-box;
 
     .ingredient-list {
-        list-style: url("../../../assets/tickicon.jpg");
+        list-style: url("../../../../assets/tickicon.jpg");
     }
     .hide {
         display: none;

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -5,7 +5,7 @@ import { Notification, MessageType } from "../pageElements/notification/Notifica
 import { useNotification } from "../../hooks/useNotification";
 import { loginService } from "../../services/login";
 import { useDispatch } from "react-redux";
-import { SET_USER_DETAILS } from "../../redux/actions";
+import { INIT_USER_RECIPES, SET_USER_DETAILS } from "../../redux/actions";
 
 const LoginForm: React.FunctionComponent = () => {
 
@@ -21,11 +21,12 @@ const LoginForm: React.FunctionComponent = () => {
 				password
 			});
 			const user = response.data;
-			dispatch(SET_USER_DETAILS(user.username, null));
-			setNotification({ type: MessageType.error, message: `${user.username} logged in successfully` });
+			dispatch(SET_USER_DETAILS(user.username, user.token));
+			dispatch(INIT_USER_RECIPES(user.recipes));
+			setNotification({ type: MessageType.message, message: `${user.username} logged in successfully` });
 			return;
 		} catch (e) {
-			//todo - can I restructure error message data? e.e.respons.data.error is messy
+			//todo - can I restructure error message data? e.e.response.data.error is messy
 			setNotification({ type: MessageType.error, message: e.e.response.data.error });
 		}
 	};

--- a/src/components/vault/UserVault.tsx
+++ b/src/components/vault/UserVault.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import { RecipeType } from "../../redux/actions";
+import { AppState } from "../../redux/store";
+import { Recipe } from "../home/recipeList/recipe/Recipe";
+
+
+const UserVault: React.FunctionComponent = () => {
+
+	const recipes = useSelector<AppState, string[]>(state => state.users.recipes);
+	console.log(recipes);
+	return (
+		<div>
+			<p>test</p>
+			{recipes.map(recipe => {
+				return (<p key={recipe}>{recipe}</p>);
+			})}
+		</div>
+	);
+};
+
+export { UserVault };

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -13,7 +13,8 @@ export type ActionWithRecipesPayload = {
 export type ActionWithSavedRecipePayload = {
 	type: string,
 	payload: {
-		recipeId: string
+		recipeId: string,
+		username: string
 	}
 }
 export type ActionWithSearchPayload = {
@@ -92,11 +93,21 @@ export const INIT_USER_RECIPES = (recipeIds: string[]) => {
 	};
 };
 
-export const SAVE_USER_RECIPE = (recipeId: string): ActionWithSavedRecipePayload => {
+export const SAVE_USER_RECIPE = (recipeId: string, username: string): ActionWithSavedRecipePayload => {
 	return {
 		type: "SAVE_USER_RECIPE",
 		payload: {
-			recipeId
+			recipeId,
+			username
+		}
+	};
+};
+export const SAVE_RECIPE = (recipeId: string, username: string): ActionWithSavedRecipePayload => {
+	return {
+		type: "SAVE_RECIPE",
+		payload: {
+			recipeId,
+			username
 		}
 	};
 };

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -1,5 +1,5 @@
 
-export type Recipe = {
+export type RecipeType = {
 	label: string,
 	url: string,
 }
@@ -7,7 +7,13 @@ export type Recipe = {
 export type ActionWithRecipesPayload = {
 	type: string,
 	payload: {
-		recipes: Recipe[]
+		recipes: RecipeType[]
+	}
+}
+export type ActionWithSavedRecipePayload = {
+	type: string,
+	payload: {
+		recipeId: string
 	}
 }
 export type ActionWithSearchPayload = {
@@ -39,7 +45,7 @@ export const GET_RECIPES = (searchTerms: string, mealTypes: string[]): ActionWit
 	};
 };
 
-export const SET_RECIPES = (recipes: Recipe[]): ActionWithRecipesPayload => {
+export const SET_RECIPES = (recipes: RecipeType[]): ActionWithRecipesPayload => {
 	return {
 		type: "SET_RECIPES",
 		payload: {
@@ -77,5 +83,22 @@ export const CLEAR_USER_DETAILS = (): ActionWithUserPayload => {
 	};
 };
 
+export const INIT_USER_RECIPES = (recipeIds: string[]) => {
+	return {
+		type: "INIT_USER_RECIPES",
+		payload: {
+			recipeIds
+		}
+	};
+};
+
+export const SAVE_USER_RECIPE = (recipeId: string): ActionWithSavedRecipePayload => {
+	return {
+		type: "SAVE_USER_RECIPE",
+		payload: {
+			recipeId
+		}
+	};
+};
 export type Actions = ReturnType<typeof SET_RECIPES>
 

--- a/src/redux/sagas.ts
+++ b/src/redux/sagas.ts
@@ -3,7 +3,7 @@
 import { put, takeLatest, all, call } from "redux-saga/effects";
 
 import { recipeService } from "../services/recipes";
-import { ActionWithSearchPayload } from "./actions";
+import { ActionWithSavedRecipePayload, ActionWithSearchPayload } from "./actions";
 
 function* fetchRecipes(action: ActionWithSearchPayload): Generator<
 	any,
@@ -11,15 +11,30 @@ function* fetchRecipes(action: ActionWithSearchPayload): Generator<
 	any
 > {
 	const recipes: any = yield call(recipeService.searchByName, action.payload.searchTerms, action.payload.mealTypes);
+
 	yield put({ type: "SET_RECIPES", payload: recipes });
+}
+
+function* saveRecipe(action: ActionWithSavedRecipePayload): Generator<
+	any,
+	any,
+	any
+> {
+	yield call(recipeService.saveToVault, action.payload.recipeId, action.payload.username);
+	yield put({ type: "SAVE_RECIPE", payload: action.payload.recipeId })
 }
 
 function* recipeWatcher() {
 	yield takeLatest("GET_RECIPES", fetchRecipes);
 }
 
+function* saveRecipeWatcher() {
+	yield takeLatest("SAVE_USER_RECIPE", saveRecipe)
+}
+
 export default function* rootSaga() {
 	yield all([
 		recipeWatcher(),
+		saveRecipeWatcher()
 	]);
 }

--- a/src/redux/userReducer.ts
+++ b/src/redux/userReducer.ts
@@ -1,20 +1,21 @@
-import { ActionWithUserPayload } from "./actions";
 
 export type UserState = {
 	user: {
 		username: string | null,
 		token: string | null
-	}
+	},
+	recipes: string[]
 }
 
 const initialState: UserState = {
 	user: {
 		username: null,
 		token: null
-	}
+	},
+	recipes: []
 };
 
-export const userReducer = (state: UserState = initialState, action: ActionWithUserPayload): UserState => {
+export const userReducer = (state: UserState = initialState, action: any): UserState => {
 	switch (action.type) {
 	case "SET_USER_DETAILS":
 		return {
@@ -32,6 +33,22 @@ export const userReducer = (state: UserState = initialState, action: ActionWithU
 				token: null
 			}
 		};
+	case "INIT_USER_RECIPES":
+		return {
+			...state,
+			recipes: [
+				...action.payload.recipeIds
+			]
+		};
+	case "SAVE_USER_RECIPE":
+		return {
+			...state,
+			recipes: [
+				...state.recipes,
+				action.payload.recipeId
+			]
+		};
+
 	default:
 		return state;
 	}

--- a/src/redux/userReducer.ts
+++ b/src/redux/userReducer.ts
@@ -40,12 +40,12 @@ export const userReducer = (state: UserState = initialState, action: any): UserS
 				...action.payload.recipeIds
 			]
 		};
-	case "SAVE_USER_RECIPE":
+	case "SAVE_RECIPE":
 		return {
 			...state,
 			recipes: [
 				...state.recipes,
-				action.payload.recipeId
+				action.payload
 			]
 		};
 

--- a/src/services/recipes.ts
+++ b/src/services/recipes.ts
@@ -19,7 +19,7 @@ const harvestRecipeData = (data: any): RecipeType[] => {//eslint-disable-line
 
 	data.hits.map((recipe: any) => {//eslint-disable-line
 		const harvestedRecipe: RecipeType = {
-			id: recipe.recipe.id,
+			id: recipe.recipe.uri,
 			label: recipe.recipe.label,
 			url: recipe.recipe.url,
 			img: recipe.recipe.image,

--- a/src/services/recipes.ts
+++ b/src/services/recipes.ts
@@ -1,6 +1,8 @@
-import axios from "axios";
+import axios, { AxiosResponse } from "axios";
 
 import { generateRequest } from "./generateRequest";
+
+const baseUrl = "http://localhost:3001";
 
 export type RecipeType = {
 	id: string,
@@ -42,6 +44,13 @@ const recipeService = {
 		const filteredResponse = harvestRecipeData(response.data);
 		console.log(filteredResponse);
 		return filteredResponse;
+	},
+
+	async saveToVault(recipeId: string, username: string): Promise<AxiosResponse> {
+		const request = `${baseUrl}/api/recipe/saveById`;
+		const response = await axios.post(request, { recipeId, username });
+		console.log(response);
+		return response.data;
 	}
 };
 

--- a/src/services/recipes.ts
+++ b/src/services/recipes.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import { generateRequest } from "./generateRequest";
 
 export type RecipeType = {
+	id: string,
 	label: string,
 	url: string,
 	img: string,
@@ -18,6 +19,7 @@ const harvestRecipeData = (data: any): RecipeType[] => {//eslint-disable-line
 
 	data.hits.map((recipe: any) => {//eslint-disable-line
 		const harvestedRecipe: RecipeType = {
+			id: recipe.recipe.id,
 			label: recipe.recipe.label,
 			url: recipe.recipe.url,
 			img: recipe.recipe.image,


### PR DESCRIPTION
closes #49 

This is a fairly large commit, which makes the following changes:

* Created a file for Recipe
* Created a `UserVault` component which, at present, renders a list of saved recipe URLs.
* Created a `SaveButton` component which renders either a filled star if the recipe is already saved, or an empty star if it is unsaved
* Renamed `Recipe` to `RecipeType` for clarity
* Added an `INIT_USER_RECIPES` action which is dispatched on successful user login (this should be moved to a new saga as soon as possible)
* Added actions `SAVE_RECIPE` and `SAVE_USER_RECIPE` (need to consider renaming), and a `saveUserRecipe` saga. `SAVE_USER_RECIPE` is dispatched when the save button is clicked. A watcher then calls `recipeService.saveToVault()`, and on completion saves the recipeId to the redux store.
* Added `recipes` to `UserState`, updated `userReducer` to handle new actions.


There is still a lot of work to be done around this area, including:

* Implementing Authorization header to include token validation
* Allow for deletion of saved recipes 
* Creating new service to get recipes by id (url) from the API
* Building the user vault to display saved recipes in a pleasing manner
