### PR TITLE
Changed app so that all recipe details saved on save

### DIFF
--- a/src/components/home/pageNavigation/PageNavigation.tsx
+++ b/src/components/home/pageNavigation/PageNavigation.tsx
@@ -14,7 +14,7 @@ const PageNavigation: React.FunctionComponent = () => {
 
 	const startOfList = useSelector<AppState, boolean>((state) => state.recipes.resultsShown.from === 0);
 	const endOfList = useSelector<AppState, boolean>((state) => state.recipes.resultsShown.to === 100);
-	const recipesAreLoaded = useSelector<AppState, boolean>((state) => state.recipes.recipes[0]?.length > 0);
+	const recipesAreLoaded = useSelector<AppState, boolean>((state) => state.recipes.recipes?.length > 0);
 
 	return (
 		<div className="page-navigation">

--- a/src/components/home/recipeList/recipe/Recipe.tsx
+++ b/src/components/home/recipeList/recipe/Recipe.tsx
@@ -21,7 +21,7 @@ const Recipe: React.FunctionComponent<RecipeProps> = ({ recipe }) => {
 
 	const { id, label, url, img, calories, source, ingredients, servings } = recipe;
 
-	const savedRecipes = useSelector<AppState, string[]>(state => state.users.recipes);
+	const savedRecipes = useSelector<AppState, RecipeType[]>(state => state.users.recipes);
 	const currentUser = useSelector<AppState, string | null>(state => state.users.user.username);
 
 	const [isHidden, setIsHidden] = useTogglable(true);
@@ -29,17 +29,21 @@ const Recipe: React.FunctionComponent<RecipeProps> = ({ recipe }) => {
 	const [notification, setNotification] = useNotification();
 
 	useEffect(() => {
-		if (savedRecipes.includes(id)) {
-			toggleIsSaved(true);
-		}
+		savedRecipes.forEach(recipe => {
+			if (recipe.id === id) {
+				toggleIsSaved(true);
+				return;
+			}
+		});
 	}, []);
+
 
 	const saveOrDeleteRecipe = (event: React.MouseEvent) => {
 		event.stopPropagation();
 		if (currentUser) {
 			if (!isSaved) {
 				toggleIsSaved();
-				dispatch(SAVE_USER_RECIPE(id, currentUser));
+				dispatch(SAVE_USER_RECIPE(recipe, currentUser));
 				setNotification({ type: MessageType.message, message: "Recipe saved!" });
 				return;
 			}

--- a/src/components/vault/UserVault.tsx
+++ b/src/components/vault/UserVault.tsx
@@ -1,18 +1,17 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import { RecipeType } from "../../redux/actions/actions";
 import { AppState } from "../../redux/store";
-import { Recipe } from "../home/recipeList/recipe/Recipe";
+import { RecipeType } from "../../services/recipes";
 
 
 const UserVault: React.FunctionComponent = () => {
 
-	const recipes = useSelector<AppState, string[]>(state => state.users.recipes);
+	const recipes = useSelector<AppState, RecipeType[]>(state => state.users.recipes);
 	return (
 		<div>
 			<p>test</p>
 			{recipes.map(recipe => {
-				return (<p key={recipe}>{recipe}</p>);
+				return (<p key={recipe.label}>{recipe.label}</p>);
 			})}
 		</div>
 	);

--- a/src/redux/actions/actions.ts
+++ b/src/redux/actions/actions.ts
@@ -1,5 +1,5 @@
-import type { RecipeType, PlainAction, ActionWithRecipesPayload, ActionWithSearchPayload } from "./recipeActions";
-export type { RecipeType, PlainAction, ActionWithRecipesPayload, ActionWithSearchPayload };
+import type { PlainAction, ActionWithRecipesPayload, ActionWithSearchPayload } from "./recipeActions";
+export type { PlainAction, ActionWithRecipesPayload, ActionWithSearchPayload };
 
 import { GET_RECIPES, SET_RECIPES, SHOW_NEXT_PAGE, SHOW_PREVIOUS_PAGE, INIT_USER_RECIPES } from "./recipeActions";
 export { GET_RECIPES, SET_RECIPES, INIT_USER_RECIPES };
@@ -11,8 +11,8 @@ export const NAVIGATION_ACTIONS = {
 };
 
 
-import type { ActionWithSavedRecipePayload } from "./saveAndDeleteActions";
-export type { ActionWithSavedRecipePayload };
+import type { ActionWithSavedRecipeIdPayload, ActionWithSavedRecipePayload } from "./saveAndDeleteActions";
+export type { ActionWithSavedRecipeIdPayload, ActionWithSavedRecipePayload };
 
 import { SAVE_RECIPE, SAVE_USER_RECIPE, DELETE_RECIPE, DELETE_USER_RECIPE } from "./saveAndDeleteActions";
 export { SAVE_RECIPE, SAVE_USER_RECIPE, DELETE_RECIPE, DELETE_USER_RECIPE };

--- a/src/redux/actions/recipeActions.ts
+++ b/src/redux/actions/recipeActions.ts
@@ -1,9 +1,4 @@
-
-export type RecipeType = {
-	label: string,
-	url: string,
-}
-
+import { RecipeType } from "../../services/recipes";
 
 export type PlainAction = {
 	type: string;

--- a/src/redux/actions/saveAndDeleteActions.ts
+++ b/src/redux/actions/saveAndDeleteActions.ts
@@ -1,22 +1,30 @@
+import { RecipeType } from "../../services/recipes";
 
-export type ActionWithSavedRecipePayload = {
+export type ActionWithSavedRecipeIdPayload = {
 	type: string,
 	payload: {
 		recipeId: string,
 		currentUser: string
 	}
 }
+export type ActionWithSavedRecipePayload = {
+	type: string,
+	payload: {
+		recipe: RecipeType,
+		currentUser: string
+	}
+}
 
-export const SAVE_USER_RECIPE = (recipeId: string, currentUser: string): ActionWithSavedRecipePayload => {
+export const SAVE_USER_RECIPE = (recipe: RecipeType, currentUser: string): ActionWithSavedRecipePayload => {
 	return {
 		type: "SAVE_USER_RECIPE",
 		payload: {
-			recipeId,
+			recipe,
 			currentUser
 		}
 	};
 };
-export const SAVE_RECIPE = (recipeId: string, currentUser: string): ActionWithSavedRecipePayload => {
+export const SAVE_RECIPE = (recipeId: string, currentUser: string): ActionWithSavedRecipeIdPayload => {
 	return {
 		type: "SAVE_RECIPE",
 		payload: {
@@ -25,7 +33,7 @@ export const SAVE_RECIPE = (recipeId: string, currentUser: string): ActionWithSa
 		}
 	};
 };
-export const DELETE_USER_RECIPE = (recipeId: string, currentUser: string): ActionWithSavedRecipePayload => {
+export const DELETE_USER_RECIPE = (recipeId: string, currentUser: string): ActionWithSavedRecipeIdPayload => {
 	return {
 		type: "DELETE_USER_RECIPE",
 		payload: {
@@ -34,7 +42,7 @@ export const DELETE_USER_RECIPE = (recipeId: string, currentUser: string): Actio
 		}
 	};
 };
-export const DELETE_RECIPE = (recipeId: string, currentUser: string): ActionWithSavedRecipePayload => {
+export const DELETE_RECIPE = (recipeId: string, currentUser: string): ActionWithSavedRecipeIdPayload => {
 	return {
 		type: "DELETE_RECIPE",
 		payload: {

--- a/src/redux/recipeReducer.ts
+++ b/src/redux/recipeReducer.ts
@@ -1,8 +1,9 @@
 import { Actions } from "./actions/actions";
 import { RESULTS_PER_PAGE } from "../constants";
+import { RecipeType } from "../services/recipes";
 
 export type RecipeState = {
-	recipes: string[];
+	recipes: RecipeType[];
 	resultsShown: {
 		from: number,
 		to: number

--- a/src/redux/sagas.ts
+++ b/src/redux/sagas.ts
@@ -4,7 +4,7 @@ import { put, takeLatest, all, call } from "redux-saga/effects";
 
 import { loginService } from "../services/login";
 import { recipeService } from "../services/recipes";
-import { ActionWithSavedRecipePayload, ActionWithSearchPayload, CLEAR_USER_DETAILS } from "./actions/actions";
+import { ActionWithSavedRecipeIdPayload, ActionWithSavedRecipePayload, ActionWithSearchPayload } from "./actions/actions";
 
 function* fetchRecipes(action: ActionWithSearchPayload): Generator<
 	any,
@@ -29,16 +29,16 @@ function* saveRecipe(action: ActionWithSavedRecipePayload): Generator<
 > {
 	yield call(
 		recipeService.saveToVault,
-		action.payload.recipeId,
+		action.payload.recipe,
 		action.payload.currentUser
 	);
 	yield put({
 		type: "SAVE_RECIPE",
-		payload: action.payload.recipeId
+		payload: action.payload.recipe
 	})
 }
 
-function* deleteRecipe(action: ActionWithSavedRecipePayload): Generator<
+function* deleteRecipe(action: ActionWithSavedRecipeIdPayload): Generator<
 	any,
 	void,
 	void

--- a/src/redux/userReducer.ts
+++ b/src/redux/userReducer.ts
@@ -1,9 +1,10 @@
+import { RecipeType } from "../services/recipes";
 
 export type UserState = {
 	user: {
 		username: string | null
 	},
-	recipes: string[],
+	recipes: RecipeType[],
 	loginError: { error: string | null }
 }
 

--- a/src/services/recipes.ts
+++ b/src/services/recipes.ts
@@ -63,13 +63,13 @@ const recipeService = {
 		return response.data;
 	},
 
-	async saveToVault(recipeId: string, currentUser: string): Promise<AxiosResponse> {
+	async saveToVault(recipe: RecipeType | any, currentUser: string): Promise<AxiosResponse> {
 		const request = `${baseUrl}/api/recipe/saveById`;
 		const token = localStorage.getItem("token");
 
 		const response = await axios.post(
 			request,
-			{ recipeId, currentUser },
+			{ recipe, currentUser },
 			{
 				headers: {
 					"authorization": `Bearer ${token}`


### PR DESCRIPTION
closes #75 

When a user saves a recipe, it makes more sense to save all the recipe details { id, label, url, img, calories, source, ingredients, servings } to their user profile. This will make it far easier and more efficient to render the user vault, as all the details will be present already in the redux store. Without this, I would need to send individual API requests for each saved recipe, which would be inefficient.

Updated project to handle all recipe details on saving, instead of just URL.